### PR TITLE
Response status handling

### DIFF
--- a/lib/dock/api/endpoints/base.rb
+++ b/lib/dock/api/endpoints/base.rb
@@ -2,6 +2,12 @@
 
 module Dock
   module Api
+    class NotFound < StandardError; end
+    class BadRequest < StandardError; end
+    class RequestError < StandardError; end
+    class Unauthorized < StandardError; end
+    class MethodNotAllowed < StandardError; end
+
     class Base
       class << self
         def connection
@@ -9,19 +15,42 @@ module Dock
         end
 
         def get(url)
-          connection.get(url).body
+          handle_status do
+            connection.get(url)
+          end
         end
 
         def delete(url)
-          connection.delete(url).body
+          handle_status do
+            connection.delete(url)
+          end
         end
 
         def post(url, data)
-          connection.post(url, data).body
+          handle_status do
+            connection.post(url, data)
+          end
         end
 
         def patch(url, data)
-          connection.patch(url, data).body
+          handle_status do
+            connection.patch(url, data)
+          end
+        end
+
+        private
+
+        def handle_status
+          response = yield
+          case response.status
+          when 400 then raise(Dock::Api::BadRequest, response.body)
+          when 401 then raise(Dock::Api::Unauthorized, response.body)
+          when 404 then raise(Dock::Api::NotFound, response.body)
+          when 405 then raise(Dock::Api::MethodNotAllowed, response.body)
+          when 500 then raise(Dock::Api::RequestError, response.body)
+          else
+            response.body
+          end
         end
       end
     end

--- a/spec/dock/api/endpoints/anchors_spec.rb
+++ b/spec/dock/api/endpoints/anchors_spec.rb
@@ -3,9 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Dock::Api::Anchors do
-  let(:anchor) do
-  end
-
   # setup anchor record
   before :all do
     VCR.use_cassette('Dock_Api_Anchors/create_anchor') do

--- a/spec/dock/api/endpoints/base_spec.rb
+++ b/spec/dock/api/endpoints/base_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dock::Api::Base do
+  context 'status handling' do
+    let(:response) { double(:response, status: status_code, body: 'body') }
+    let(:connection) { double(:connection, get: response) }
+
+    before do
+      allow(described_class).to receive(:connection) { connection }
+    end
+
+    context 'when 200' do
+      let(:status_code) { 200 }
+
+      it 'returns response body' do
+        expect(described_class.get('/')).to eq('body')
+      end
+    end
+
+    context 'when 400' do
+      let(:status_code) { 400 }
+
+      it 'raises excepton' do
+        expect do
+          described_class.get('/')
+        end.to raise_error(Dock::Api::BadRequest, 'body')
+      end
+    end
+
+    context 'when 401' do
+      let(:status_code) { 401 }
+
+      it 'raises excepton' do
+        expect do
+          described_class.get('/')
+        end.to raise_error(Dock::Api::Unauthorized, 'body')
+      end
+    end
+
+    context 'when 404' do
+      let(:status_code) { 404 }
+
+      it 'raises excepton' do
+        expect do
+          described_class.get('/')
+        end.to raise_error(Dock::Api::NotFound, 'body')
+      end
+    end
+
+    context 'when 405' do
+      let(:status_code) { 405 }
+
+      it 'raises excepton' do
+        expect do
+          described_class.get('/')
+        end.to raise_error(Dock::Api::MethodNotAllowed, 'body')
+      end
+    end
+
+    context 'when 500' do
+      let(:status_code) { 500 }
+
+      it 'raises excepton' do
+        expect do
+          described_class.get('/')
+        end.to raise_error(Dock::Api::RequestError, 'body')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- handles basic HTTP statuses by raising exception for 400, 401, 405, 500 and returning body in case of 200.